### PR TITLE
Rename sum function

### DIFF
--- a/polyround.scad
+++ b/polyround.scad
@@ -451,7 +451,7 @@ function CWorCCW(p)=
       (p[listWrap(i+0,Lp)].x-p[listWrap(i+1,Lp)].x)*(p[listWrap(i+0,Lp)].y+p[listWrap(i+1,Lp)].y)
     ]
   )  
-  sign(sum(e));
+  sign(polySum(e));
 
 function CentreN2PointsArc(p1,p2,cen,mode=0,fn)=
   /* This function plots an arc from p1 to p2 with fn increments using the cen as the centre of the arc.
@@ -685,8 +685,8 @@ function cosineRuleAngle(p1,p2,p3)=
   )
   acos((sq(p23)+sq(p12)-sq(p13))/(2*p23*p12));
 
-function sum(list, idx = 0, result = 0) = 
-	idx >= len(list) ? result : sum(list, idx + 1, result + list[idx]);
+function polySum(list, idx = 0, result = 0) = 
+	idx >= len(list) ? result : polySum(list, idx + 1, result + list[idx]);
 
 function sq(x)=x*x;
 function getGradient(p1,p2)=(p2.y-p1.y)/(p2.x-p1.x);


### PR DESCRIPTION
This name is rather generic and has a high chance of conflicting with other libraries(e.g. BOSL2) or user-defined functions.

This issue was found while I was working on a project which requires the use of both popular libraries - Round-Anything & BOSL2.

```
WARNING polyround.scad:689 undefined operation (number + vector)
WARNING polyround.scad:689 undefined operation (number + vector)
WARNING math.scad:663 undefined operation(undefined / number)     <-- this is from BOSL2
ERROR vectors.scad:211 Asserting 'is_vector(v)' failed: Invalid vector      <-- this is from BOSL2
```
This change fixed the issue for me locally.

There aren't any other function names/signatures conflicts between these 2 libraries.

I believe this is a safe update because this function is not present in public API and is only used internally